### PR TITLE
Multi: Add Specific URLs to TIGER Files

### DIFF
--- a/configs/jurisdictions/co.yml
+++ b/configs/jurisdictions/co.yml
@@ -4,9 +4,12 @@ id-mappings:
   sldl:
     key: DISTRICT
     sld-match: 'sldl-080([\d]+)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/08_COLORADO/08/tl_rd22_08_sldl_whole_block.zip
   sldu:
     key: DISTRICT
     sld-match: 'sldu-080([\d]+)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/08_COLORADO/08/tl_rd22_08_sldu_whole_block.zip
   cd:
     key: DISTRICT
     sld-match: 'cd-080(\d)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/08_COLORADO/08/tl_rd22_08_cd118_whole_block.zip

--- a/configs/jurisdictions/de.yml
+++ b/configs/jurisdictions/de.yml
@@ -7,6 +7,7 @@ id-mappings:
   sldu:
     key: DISTRICT
     sld-match: 'sldu-100([\d]+)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/10_DELAWARE/10/tl_rd22_10_sldu_whole_block.zip
   cd:
     key: DISTRICT
     sld-match: 'cd-100(\d)'

--- a/configs/jurisdictions/mn.yml
+++ b/configs/jurisdictions/mn.yml
@@ -5,9 +5,11 @@ id-mappings:
     key: DISTRICT
     sld-match: 'sldl-27(\d+[A-Z])'
     match-type: str
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/27_MINNESOTA/27/tl_rd22_27_sldl_whole_block.zip
   sldu:
     key: DISTRICT
     sld-match: 'sldu-270([\d]+)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/27_MINNESOTA/27/tl_rd22_27_sldu_whole_block.zip
   cd:
     key: DISTRICT
     sld-match: 'cd-270(\d)'

--- a/configs/jurisdictions/nd.yml
+++ b/configs/jurisdictions/nd.yml
@@ -4,9 +4,11 @@ id-mappings:
   sldl:
     key: DISTRICT
     sld-match: 'sldl-380(\d+[A-Z]?)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/38_NORTH_DAKOTA/38/tl_rd22_38_sldl_whole_block.zip
   sldu:
     key: DISTRICT
     sld-match: 'sldu-380([\d]+)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/38_NORTH_DAKOTA/38/tl_rd22_38_sldu_whole_block.zip
   cd:
     key: DISTRICT
     sld-match: 'cd-380(\d)'

--- a/configs/jurisdictions/pa.yml
+++ b/configs/jurisdictions/pa.yml
@@ -4,6 +4,7 @@ id-mappings:
   sldl:
     key: DISTRICT
     sld-match: 'sldl-42([\d]+)'
+    url: https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/42_PENNSYLVANIA/42/tl_rd22_42_sldl_whole_block.zip
   sldu:
     key: DISTRICT
     sld-match: 'sldu-420([\d]+)'


### PR DESCRIPTION
Had an issue with a bunch of 404s showing up when trying to get general files. Looks like they are splitting the files up into `split` & `whole` block files.
[dag_id=openstates-geo-update_run_id=scheduled__2024-03-01T00_00_00+00_00_task_id=openstates-geo-update_attempt=1.log](https://github.com/openstates/openstates-geo/files/14890136/dag_id.openstates-geo-update_run_id.scheduled__2024-03-01T00_00_00%2B00_00_task_id.openstates-geo-update_attempt.1.log)
